### PR TITLE
Feat: Use input type number inputs on Advanced options tab

### DIFF
--- a/components/CreatePage/AdvancedOptionsPanel/advancedOptionsPanel.tsx
+++ b/components/CreatePage/AdvancedOptionsPanel/advancedOptionsPanel.tsx
@@ -637,7 +637,7 @@ const AdvancedOptionsPanel = ({
           <Input
             // @ts-ignore
             className="mb-2"
-            type="number"
+            type="text"
             name="seed"
             onChange={handleChangeInput}
             // @ts-ignore

--- a/components/CreatePage/AdvancedOptionsPanel/advancedOptionsPanel.tsx
+++ b/components/CreatePage/AdvancedOptionsPanel/advancedOptionsPanel.tsx
@@ -527,7 +527,9 @@ const AdvancedOptionsPanel = ({
             // @ts-ignore
             error={errorMessage.steps}
             className="mb-2"
-            type="text"
+            type="number"
+            min="1"
+            max="50"
             name="steps"
             onChange={handleChangeInput}
             onBlur={() => {
@@ -561,7 +563,9 @@ const AdvancedOptionsPanel = ({
             // @ts-ignore
             error={errorMessage.cfg_scale}
             className="mb-2"
-            type="text"
+            type="number"
+            min="1"
+            max="30"
             name="cfg_scale"
             onBlur={(e: any) => {
               if (
@@ -608,7 +612,10 @@ const AdvancedOptionsPanel = ({
             <Input
               // @ts-ignore
               className="mb-2"
-              type="text"
+              type="number"
+              step="0.05"
+              min="0"
+              max="1.0"
               name="denoising_strength"
               onChange={handleChangeInput}
               // @ts-ignore
@@ -630,7 +637,7 @@ const AdvancedOptionsPanel = ({
           <Input
             // @ts-ignore
             className="mb-2"
-            type="text"
+            type="number"
             name="seed"
             onChange={handleChangeInput}
             // @ts-ignore
@@ -916,7 +923,9 @@ const AdvancedOptionsPanel = ({
                 // @ts-ignore
                 className="mb-2"
                 error={errorMessage.numImages}
-                type="text"
+                type="number"
+                min="1"
+                max={MAX_IMAGES_PER_JOB}
                 name="numImages"
                 onChange={handleChangeInput}
                 onBlur={(e: any) => {


### PR DESCRIPTION
For better user input (like with the arrow keys) use the `type="number"` inputs and its min/max/step attributes to early prevent triggering the validation.

Looks like this e.g. in Firefox
![Screenshot 2022-12-02 at 10 29 47](https://user-images.githubusercontent.com/3186201/205261178-7c3aebab-2275-4bcd-b851-6eb862948c56.png)
