### PR TITLE
feat: use serchable input for sampler, model, multiple model

### DIFF
--- a/components/CreatePage/AdvancedOptionsPanel/advancedOptionsPanel.tsx
+++ b/components/CreatePage/AdvancedOptionsPanel/advancedOptionsPanel.tsx
@@ -500,7 +500,7 @@ const AdvancedOptionsPanel = ({
                 setInput({ sampler: obj.value })
                 localStorage.setItem('sampler', obj.value)
               }}
-              isSearchable={false}
+              isSearchable={true}
               value={samplerValue}
             />
           </MaxWidth>
@@ -698,7 +698,7 @@ const AdvancedOptionsPanel = ({
                 }}
                 // @ts-ignore
                 value={modelsValue}
-                isSearchable={false}
+                isSearchable={true}
               />
             </MaxWidth>
             {modelDetails[input.models[0]]?.showcases && (
@@ -834,7 +834,7 @@ const AdvancedOptionsPanel = ({
               }}
               // @ts-ignore
               value={modelsValue}
-              isSearchable={false}
+              isSearchable={true}
             />
           </MaxWidth>
         </Section>


### PR DESCRIPTION
Hi Dave!
I have another UX optimization proposal: 
using serchable inputs for sampler, model, multiple model makes it easier to find the desired entries, since lists are getting longer.

Looks like this:
![Screenshot 2022-12-05 at 16 13 37](https://user-images.githubusercontent.com/3186201/205681410-ccda994b-37f3-4d27-b21c-ca8efdc7ad7b.png)
