### PR TITLE
set lora inputmode to numeric

### DIFF
--- a/modules/LoraSelect/LoadLoraFromCivitai.tsx
+++ b/modules/LoraSelect/LoadLoraFromCivitai.tsx
@@ -96,6 +96,7 @@ const LoadLora = ({
           type="text"
           name="filterLoras"
           placeholder="Civitai LoRA ID or URL"
+          inputmode="numeric"
           onChange={(e: any) => {
             setLoraId(e.target.value)
           }}


### PR DESCRIPTION
unlike setting a pattern or input type=number, setting inputmode doesn't actually restrict
you, so you can still paste in URLs. however, instead of popping up a text keyboard on
mobile, it pops the numbers keyboard. nobody's going to be typing out full URLs here, so
unless you add a search by name, there's no reason to type in letters.
