### PR TITLE
disable keyboard popup onnexport

### DIFF
--- a/components/CreatePage/AdvancedOptionsPanel/NumericInputSlider/index.tsx
+++ b/components/CreatePage/AdvancedOptionsPanel/NumericInputSlider/index.tsx
@@ -110,6 +110,7 @@ const NumericInputSlider = ({
           <NumberInput
             className="mb-2"
             type="text"
+            inputMode="numeric"
             min={from}
             max={to}
             step={step}

--- a/components/ImportExportPanel/importExportPanel.tsx
+++ b/components/ImportExportPanel/importExportPanel.tsx
@@ -172,6 +172,7 @@ const ImportExportPanel = () => {
                   onChange={(option: any) => {
                     setComponentState({ filesPerZip: option })
                   }}
+                  inputMode="none"
                   value={componentState.filesPerZip}
                 />
               </div>


### PR DESCRIPTION
more input mode! this time, set it to none to prevent the keyboard from popping up. since there's only a few options, this is ok

reasoning: I tapped the button to select 750 instead of 250, and the keyboard pop-up caused the entire page to scroll just as I tapped the 750; instead I tapped on a diaper link I didn't intend to, marking the 7th (or whatever number) section as downloaded. frustratingly, the 7th(?) download remained inaccessible even after I changed the number, so I had to reload the page...and very nearly did it again