### PR TITLE
Add missing import/export menu item to the side menu

### DIFF
--- a/components/Menu/menu.tsx
+++ b/components/Menu/menu.tsx
@@ -327,6 +327,14 @@ const Menu = () => {
               <LineDashedIcon />
               ArtBot Prefs
             </SubOption>
+            <SubOption
+              onClick={() => {
+                navigateToLink('/settings?panel=import-export')
+              }}
+            >
+              <LineDashedIcon />
+              Import / Export
+            </SubOption>
           </SubOptions>
           <MenuOption
             onClick={() => {


### PR DESCRIPTION
I noticed this menu option was missing in the mobile view, and confirmed it was also missing in the desktop view.