### PR TITLE
Add image parameters to jpeg exif metadata 

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "node-cron": "3.0.2",
     "node-fetch": "^3.3.2",
     "node-localstorage": "2.2.1",
+    "piexifjs": "^1.0.6",
     "react": "18.2.0",
     "react-colorful": "5.6.1",
     "react-dom": "18.2.0",

--- a/utils/blobUtils.ts
+++ b/utils/blobUtils.ts
@@ -48,9 +48,17 @@ function dataURItoBlob(dataURI: string, userComment: string) {
   var mimeString = dataURI.split(',')[0].split(':')[1].split(';')[0]
 
   // Add exif data if filetype is jpeg, and userComment is set
-  if (userComment && mimeString == "image/jpeg") {
-    const exif = {[piexif.ExifIFD.UserComment]: `ASCII\0\0\0${userComment}`};
-    const exifObj = {"Exif":exif};
+  if (mimeString == "image/jpeg") {
+    const zeroth = {
+      [piexif.ImageIFD.Software]: "ArtBot - Create images with Stable Diffusion, utilizing the AI Horde"
+    };
+    const exif = userComment ? {
+      [piexif.ExifIFD.UserComment]: `ASCII\0\0\0${userComment}`
+    } : undefined;
+    const exifObj = {
+      "0th": zeroth,
+      "Exif": exif
+    };
     const exifbytes = piexif.dump(exifObj);
     byteString = piexif.insert(exifbytes, byteString)
   }

--- a/utils/blobUtils.ts
+++ b/utils/blobUtils.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck
+import piexif from 'piexifjs';
 
 export const initBlob = () => {
   if (!Blob.prototype.toPNG) {
@@ -14,8 +15,8 @@ export const initBlob = () => {
   }
 
   if (!Blob.prototype.toJPEG) {
-    Blob.prototype.toJPEG = function (callback: any) {
-      return convertBlob(this, 'image/jpeg', callback)
+    Blob.prototype.toJPEG = function (callback: any, userComment: string) {
+      return convertBlob(this, 'image/jpeg', callback, userComment)
     }
   }
 }
@@ -23,7 +24,8 @@ export const initBlob = () => {
 function convertBlob(
   blob: Blob | MediaSource,
   type: string,
-  callback: (arg0: Blob) => void
+  callback: (arg0: Blob) => void,
+  userComment: string,
 ) {
   return new Promise((resolve) => {
     let canvas = <HTMLCanvasElement>createTempCanvas()
@@ -34,16 +36,25 @@ function convertBlob(
       canvas.width = image.width
       canvas.height = image.height
       ctx.drawImage(image, 0, 0)
-      let result = dataURItoBlob(canvas.toDataURL(type, 1))
+      let result = dataURItoBlob(canvas.toDataURL(type, 1), userComment)
       if (callback) callback(result)
       else resolve(result)
     }
   })
 }
 
-function dataURItoBlob(dataURI: string) {
+function dataURItoBlob(dataURI: string, userComment: string) {
   var byteString = atob(dataURI.split(',')[1])
   var mimeString = dataURI.split(',')[0].split(':')[1].split(';')[0]
+
+  // Add exif data if filetype is jpeg, and userComment is set
+  if (userComment && mimeString == "image/jpeg") {
+    const exif = {[piexif.ExifIFD.UserComment]: `ASCII\0\0\0${userComment}`};
+    const exifObj = {"Exif":exif};
+    const exifbytes = piexif.dump(exifObj);
+    byteString = piexif.insert(exifbytes, byteString)
+  }
+
   var ab = new ArrayBuffer(byteString.length)
   var ia = new Uint8Array(ab)
   for (var i = 0; i < byteString.length; i++) {

--- a/utils/imageUtils.ts
+++ b/utils/imageUtils.ts
@@ -729,8 +729,13 @@ export const downloadFile = async (image: any) => {
     }
 
     if (fileType === 'jpg') {
+      // For jpeg, add image parameters in exif metadata
+      const metaData: string = `${image.prompt}\n` +
+        `Steps: ${image.steps}, Sampler: ${image.sampler}, CFG scale: ${image.cfg_scale}, Seed: ${image.seed}` +
+        `, Size: ${image.width}x${image.height}, model: ${image.models}`
+
       // @ts-ignore
-      newBlob = await input?.toJPEG()
+      newBlob = await input?.toJPEG(null, metaData)
     }
 
     if (fileType === 'webp') {


### PR DESCRIPTION
Following a discussion here: https://discord.com/channels/781145214752129095/1081743238194536458/1139584345628213400

It'd be nice to store the image parameters in exported images.
This MR implements this for the jpeg file format. WebP support takes a bit more work, as this is not implemented in the piexifjs library yet. (but I might work on that at a later date).

Let me know what you think. Also let me know if you want a setting for this, I'd be happy to implement that.