### PR TITLE
Add image parameters to webp exif data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "next-horde",
       "version": "0.1.0",
       "dependencies": {
+        "@asc0910/exif-library": "github:asc0910/exif-library",
         "@ebay/nice-modal-react": "1.2.10",
         "@next/bundle-analyzer": "13.4.19",
         "@radix-ui/react-checkbox": "1.0.4",
@@ -37,7 +38,6 @@
         "node-cron": "3.0.2",
         "node-fetch": "^3.3.2",
         "node-localstorage": "2.2.1",
-        "piexifjs": "^1.0.6",
         "react": "18.2.0",
         "react-colorful": "5.6.1",
         "react-dom": "18.2.0",
@@ -132,6 +132,11 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@asc0910/exif-library": {
+      "version": "2.0.3",
+      "resolved": "git+ssh://git@github.com/asc0910/exif-library.git#bb87d8f357215dd6f09b86696e06dd49c91f1966",
+      "license": "MIT"
     },
     "node_modules/@assortment/darkmodejs": {
       "version": "1.2.1",
@@ -11850,11 +11855,6 @@
       "engines": {
         "node": ">=0.10"
       }
-    },
-    "node_modules/piexifjs": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/piexifjs/-/piexifjs-1.0.6.tgz",
-      "integrity": "sha512-0wVyH0cKohzBQ5Gi2V1BuxYpxWfxF3cSqfFXfPIpl5tl9XLS5z4ogqhUCD20AbHi0h9aJkqXNJnkVev6gwh2ag=="
     },
     "node_modules/pify": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     }
   },
   "dependencies": {
+    "@asc0910/exif-library": "github:asc0910/exif-library",
     "@ebay/nice-modal-react": "1.2.10",
     "@next/bundle-analyzer": "13.4.19",
     "@radix-ui/react-checkbox": "1.0.4",
@@ -60,7 +61,6 @@
     "node-cron": "3.0.2",
     "node-fetch": "^3.3.2",
     "node-localstorage": "2.2.1",
-    "piexifjs": "^1.0.6",
     "react": "18.2.0",
     "react-colorful": "5.6.1",
     "react-dom": "18.2.0",

--- a/utils/blobUtils.ts
+++ b/utils/blobUtils.ts
@@ -61,7 +61,6 @@ function dataURItoBlob(dataURI: string, userComment: string) {
     '0th': zeroth,
     Exif: exif
   }
-
   const exifbytes = exifLib.dump(exifObj)
   byteString = exifLib.insert(exifbytes, byteString)
 
@@ -78,4 +77,23 @@ function createTempCanvas() {
   let canvas = document.createElement('CANVAS')
   canvas.style.display = 'none'
   return canvas
+}
+
+export function blobToBase64(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onloadend = function () {
+      if (reader.result) {
+        resolve(reader.result as string)
+      } else {
+        const err = new Error('Failed to convert blob to base64')
+        console.error(err)
+        reject(err)
+      }
+    }
+    reader.onerror = function (error) {
+      reject(error)
+    }
+    reader.readAsDataURL(blob)
+  })
 }

--- a/utils/imageCache.ts
+++ b/utils/imageCache.ts
@@ -43,6 +43,8 @@ import {
   updatePendingJobId,
   updatePendingJobV2
 } from 'controllers/pendingJobsCache'
+import { base64toBlob } from './imageUtils'
+import { initBlob, blobToBase64 } from './blobUtils'
 
 export const initIndexedDb = () => {}
 
@@ -785,6 +787,28 @@ export const checkCurrentJob = async (imageDetails: any) => {
       for (const idx in imgDetailsFromApi.generations) {
         const image = imgDetailsFromApi.generations[idx]
         if ('base64String' in image && image.base64String) {
+          initBlob()
+          // Insert exif information in the image
+          // TODO: Refactor: extract
+          const metaData: string =
+            `${job.prompt}\n` +
+            (job.negative ? `Negative prompt: ${job.negative}\n` : ``) +
+            `Steps: ${job.steps}, Sampler: ${job.sampler}, CFG scale: ${job.cfg_scale}, Seed: ${image.seed}` +
+            `, Size: ${job.width}x${job.height}, model: ${job.models}`
+          let oldBlob
+          try {
+            oldBlob = await base64toBlob(image.base64String, `image/webp`)
+          } catch (err) {
+            console.log(
+              `Error: Something unfortunate happened when attempting to convert base64string to file blob`
+            )
+            console.log(err)
+            continue
+          }
+          // @ts-ignore
+          let newBlob = await oldBlob?.toWebP(null, metaData)
+          image.base64String = (await blobToBase64(newBlob)).split(',')[1]
+
           const jobWithImageDetails = {
             ...job,
             ...image,

--- a/utils/imageCache.ts
+++ b/utils/imageCache.ts
@@ -789,7 +789,6 @@ export const checkCurrentJob = async (imageDetails: any) => {
         if ('base64String' in image && image.base64String) {
           initBlob()
           // Insert exif information in the image
-          // TODO: Refactor: extract
           const metaData: string =
             `${job.prompt}\n` +
             (job.negative ? `Negative prompt: ${job.negative}\n` : ``) +
@@ -806,7 +805,7 @@ export const checkCurrentJob = async (imageDetails: any) => {
             continue
           }
           // @ts-ignore
-          let newBlob = await oldBlob?.toWebP(null, metaData)
+          let newBlob = await oldBlob?.addOrUpdateExifData(metaData)
           image.base64String = (await blobToBase64(newBlob)).split(',')[1]
 
           const jobWithImageDetails = {

--- a/utils/imageUtils.ts
+++ b/utils/imageUtils.ts
@@ -678,29 +678,22 @@ export const downloadFile = async (image: any) => {
   if (image.imageMimeType == `image/${fileType}`) {
     saveAs(input, filename)
   } else {
-    // Add image parameters in exif metadata
-    const metaData: string =
-      `${image.prompt}\n` +
-      (image.negative ? `Negative prompt: ${image.negative}\n` : ``) +
-      `Steps: ${image.steps}, Sampler: ${image.sampler}, CFG scale: ${image.cfg_scale}, Seed: ${image.seed}` +
-      `, Size: ${image.width}x${image.height}, model: ${image.models}`
-
     // otherwise we'll convert if necessary
     let newBlob
 
     if (fileType === 'png') {
       // @ts-ignore
-      newBlob = await input?.toPNG(null, metaData)
+      newBlob = await input?.toPNG(null)
     }
 
     if (fileType === 'jpg') {
       // @ts-ignore
-      newBlob = await input?.toJPEG(null, metaData)
+      newBlob = await input?.toJPEG(null)
     }
 
     if (fileType === 'webp') {
       // @ts-ignore
-      newBlob = await input?.toWebP(null, metaData)
+      newBlob = await input?.toWebP(null)
     }
 
     saveAs(newBlob, filename)

--- a/utils/imageUtils.ts
+++ b/utils/imageUtils.ts
@@ -678,29 +678,29 @@ export const downloadFile = async (image: any) => {
   if (image.imageMimeType == `image/${fileType}`) {
     saveAs(input, filename)
   } else {
+    // Add image parameters in exif metadata
+    const metaData: string =
+      `${image.prompt}\n` +
+      (image.negative ? `Negative prompt: ${image.negative}\n` : ``) +
+      `Steps: ${image.steps}, Sampler: ${image.sampler}, CFG scale: ${image.cfg_scale}, Seed: ${image.seed}` +
+      `, Size: ${image.width}x${image.height}, model: ${image.models}`
+
     // otherwise we'll convert if necessary
     let newBlob
 
     if (fileType === 'png') {
       // @ts-ignore
-      newBlob = await input?.toPNG()
+      newBlob = await input?.toPNG(null, metaData)
     }
 
     if (fileType === 'jpg') {
-      // For jpeg, add image parameters in exif metadata
-      const metaData: string =
-        `${image.prompt}\n` +
-        (image.negative ? `Negative prompt: ${image.negative}\n` : ``) +
-        `Steps: ${image.steps}, Sampler: ${image.sampler}, CFG scale: ${image.cfg_scale}, Seed: ${image.seed}` +
-        `, Size: ${image.width}x${image.height}, model: ${image.models}`
-
       // @ts-ignore
       newBlob = await input?.toJPEG(null, metaData)
     }
 
     if (fileType === 'webp') {
       // @ts-ignore
-      newBlob = await input?.toWebP()
+      newBlob = await input?.toWebP(null, metaData)
     }
 
     saveAs(newBlob, filename)


### PR DESCRIPTION
As proposed by rockbandit [here](https://discord.com/channels/781145214752129095/1140737364885524652).

- exif metadata support for the .webp and .png file formats
- Now, we add exif data to the webp byte-stream as soon as it's downloaded from the server, even before it's written to browser localstorage. This way, exif data is always available, even when the user drag-and-drops the image from the webinterface or uses <righ click>->save as, as well as when using the happy path download button.