### PR TITLE
fix max image size and megapixels calculation

### DIFF
--- a/_constants/index.ts
+++ b/_constants/index.ts
@@ -14,7 +14,7 @@ export const MAX_IMAGES_PER_JOB = 200
 export const MAX_DIMENSIONS_LOGGED_IN = 3072
 export const MAX_DIMENSIONS_LOGGED_OUT = 1024
 export const MAX_STEPS_LOGGED_IN = 500
-export const MAX_IMAGE_PIXELS = 4194303 // Maximum supported resolution for image requests to the AI Horde
+export const MAX_IMAGE_PIXELS = 4194304 // Maximum supported resolution for image requests to the AI Horde
 export const POLL_COMPLETED_JOBS_INTERVAL = 1500 // ms
 
 // TODO: Move into Samplers model file and add better ways to sort based on input type (txt2img vs img2img)

--- a/app/_modules/AdvancedOptionsPanel/ImageOrientationOptions/index.tsx
+++ b/app/_modules/AdvancedOptionsPanel/ImageOrientationOptions/index.tsx
@@ -63,8 +63,7 @@ const ImageOrientationOptions = ({ input, setInput }: GetSetPromptInput) => {
 
   const getMegapixelSize = () => {
     const size = input.height * input.width
-    const megapixel = 1024 * 1024
-    return (size / megapixel).toFixed(2)
+    return (size / 1E6).toFixed(2)
   }
 
   const toggleKeepAspectRatio = () => {


### PR DESCRIPTION
- update max image size
- fix megapixel calculation. 1mp is 1,000,000px...
  - why does this even set consts instead of just using the inputs directly when they only get used once?
